### PR TITLE
Adding _ as an allowed symbol for atoms

### DIFF
--- a/OpenCCG.ebnf
+++ b/OpenCCG.ebnf
@@ -45,5 +45,5 @@ variable_type::str
     ;
 
 atom::str
-    = /[a-zA-Z\-\.]+/
+    = /[a-zA-Z\-\._]+/
     ;

--- a/app/generated_openccg_parser.py
+++ b/app/generated_openccg_parser.py
@@ -262,7 +262,7 @@ class OpenCCGParser(Parser):
 
     @tatsumasu('str')
     def _atom_(self):  # noqa
-        self._pattern(r'[a-zA-Z\-\.]+')
+        self._pattern(r'[a-zA-Z\-\._]+')
 
 
 class OpenCCGSemantics(object):


### PR DESCRIPTION
An alternative grammar used "take_turn", which caused the parser to have a hickup. I added it to the EBNF grammar and updated the parser.