### PR TITLE
Using image instead build context for docker.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,4 @@ version: "3.2"
 services:
 
     openccg:
-        build: .
+        image: web-openccg:latest


### PR DESCRIPTION
This should allow the docker container registry to pick up the proper
image during the jenkins auto deployment.

The image can be built and tagged using `make build`.