### PR TITLE
Using two different docker-compose files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
 
         stage('deploy') {
             steps {
-                sh 'docker-compose --project-name litmus up --detach --renew-anon-volumes --force-recreate'
+                sh 'docker-compose -f docker-compose.deploy.yaml --project-name litmus up --detach --renew-anon-volumes --force-recreate'
             }
             when {
                 branch 'master'

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -4,4 +4,4 @@ version: "3.2"
 services:
 
     openccg:
-        build: .
+        image: web-openccg:latest


### PR DESCRIPTION
One uses the local build context and one uses the container registry.

This allows very straight forward local testing but uses the same mechanisms for a deployment by providing a different configuration.