### PR TITLE
Integrating openccg-gum-cooking to build web-openccg as needed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ RUN curl -o openccg-${OPENCCG_VERSION}.tgz https://datapacket.dl.sourceforge.net
     && tar zxf openccg-${OPENCCG_VERSION}.tgz \
     && rm openccg-${OPENCCG_VERSION}.tgz \
 # Download and extract grammar
-    && curl -O -L https://github.com/shoeffner/openccg-gum-cooking/archive/${GRAMMAR_VERSION}.zip \
-    && unzip -d /tmp ${GRAMMAR_VERSION}.zip \
-    && mv /tmp/openccg-gum-cooking-${GRAMMAR_VERSION}/english-cooking /grammar \
-    && rm ${GRAMMAR_VERSION}.zip \
-    && rm -rf /tmp/openccg-gum-cooking-${GRAMMAR_VERSION} \
+    && curl -o grammar.zip -L https://github.com/shoeffner/openccg-gum-cooking/archive/${GRAMMAR_VERSION}.zip \
+    && unzip -d /tmp grammar.zip \
+    && mv /tmp/openccg-gum-cooking-*/english-cooking /grammar \
+    && rm grammar.zip \
+    && rm -rf /tmp/openccg-gum-cooking-* \
 # Download viz.js
     && mkdir -p /app/webopenccg/static \
     && curl -L -o /app/webopenccg/static/viz.js https://github.com/mdaines/viz.js/releases/download/v2.0.0/viz.js \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ LABEL maintainer="Sebastian Höffner <shoeffner@tzi.de>"
 LABEL description="A small webapp to parse sentences using the DiaSpace grammar (University of Bremen) with OpenCCG."
 LABEL version="2.1"
 
+ARG GRAMMAR_VERSION=master
+ARG OPENCCG_VERSION=0.9.5
+
 EXPOSE 5000 8080
 
 ENV OPENCCG_HOME /openccg
@@ -11,13 +14,15 @@ ENV PATH "$OPENCCG_HOME/bin:$PATH"
 ENV LD_LIBRARY_PATH "$OPENCCG_HOME/lib:$LD_LIBRARY_PATH"
 
 # Download and extract OpenCCG
-RUN curl -o openccg-0.9.5.tgz https://datapacket.dl.sourceforge.net/project/openccg/openccg/openccg%20v0.9.5%20-%20deplen%2C%20kenlm%2C%20disjunctivizer/openccg-0.9.5.tgz \
-    && tar zxf openccg-0.9.5.tgz \
-    && rm openccg-0.9.5.tgz \
+RUN curl -o openccg-${OPENCCG_VERSION}.tgz https://datapacket.dl.sourceforge.net/project/openccg/openccg/openccg%20v${OPENCCG_VERSION}%20-%20deplen%2C%20kenlm%2C%20disjunctivizer/openccg-${OPENCCG_VERSION}.tgz \
+    && tar zxf openccg-${OPENCCG_VERSION}.tgz \
+    && rm openccg-${OPENCCG_VERSION}.tgz \
 # Download and extract grammar
-    && curl -O http://www.diaspace.uni-bremen.de/twiki/pub/DiaSpace/ReSources/english.zip \
-    && unzip -d /english english.zip \
-    && rm english.zip \
+    && curl -O -L https://github.com/shoeffner/openccg-gum-cooking/archive/${GRAMMAR_VERSION}.zip \
+    && unzip -d /tmp ${GRAMMAR_VERSION}.zip \
+    && mv /tmp/openccg-gum-cooking-${GRAMMAR_VERSION}/english-cooking /grammar \
+    && rm ${GRAMMAR_VERSION}.zip \
+    && rm -rf /tmp/openccg-gum-cooking-${GRAMMAR_VERSION} \
 # Download viz.js
     && mkdir -p /app/webopenccg/static \
     && curl -L -o /app/webopenccg/static/viz.js https://github.com/mdaines/viz.js/releases/download/v2.0.0/viz.js \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     stages {
         stage('build') {
             steps {
-                sh 'docker build . --no-cache -t web-openccg:$(git rev-parse --short HEAD)'
+                sh 'docker build . --no-cache --build-arg GRAMMAR_VERSION=legacy/grammar -t web-openccg:$(git rev-parse --short HEAD)'
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ webopenccg/generated_openccg_parser.py: OpenCCG.ebnf
 
 .PHONY: build
 build:
-	docker build . -t web-openccg
+	docker build . --build-arg GRAMMAR_VERSION=legacy/grammar -t web-openccg
 
 webopenccg/static/%.js:
 	docker run --rm --detach --name web-openccg-build-$(notdir $@) web-openccg

--- a/webopenccg/wccg.py
+++ b/webopenccg/wccg.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 import re
 import string
 import subprocess
@@ -25,7 +26,7 @@ def parse(sentence):
     if not sentence:
         return dict(error='No sentence provided.', http_status=400)
 
-    wccg_proc = subprocess.Popen(['wccg', '-showsem', '-showall', '/english'],
+    wccg_proc = subprocess.Popen(['wccg', '-showsem', '-showall', os.environ.get('GRAMMAR_DIR', '/grammar')],
                                  stdin=subprocess.PIPE,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.DEVNULL,


### PR DESCRIPTION
This allows to build openccg with the grammars developed in https://github.com/shoeffner/openccg-gum-cooking. For the moment, a legacy version is used (i.e. the version which was used in web-openccg anyways).

This closes #38 .