### PR TITLE
Switching to Debian Stable 

### DIFF
--- a/webopenccg/wccg.py
+++ b/webopenccg/wccg.py
@@ -21,7 +21,7 @@ class WCCGProcess:
         self._new_repl()
 
     def _new_repl(self):
-        self.repl = REPLWrapper(f'wccg -prompt {PEXPECT_PROMPT} -showsem -showall {os.environ.get("GRAMMAR_DIR", "/grammar")}', PEXPECT_PROMPT + ' ', None)
+        self.repl = REPLWrapper(f'wccg -prompt "{PEXPECT_PROMPT}" -showsem -showall {os.environ.get("GRAMMAR_DIR", "/grammar")}', PEXPECT_PROMPT + ' ', None)
 
     def parse(self, sentence):
         """Parse a sentence by passing it to the wccg process and read the results.


### PR DESCRIPTION
Jenkins built with Debian Unstable which comes with Python 3.7. However, local builds used Debian Stable. This PR works around that issue by compiling OpenCCG with Python 2 and then pulling in Python 3 for web-openccg.

Thanks @vanjaSophie for reporting.